### PR TITLE
fix: correct harden-runner SHA to v2.19.1

### DIFF
--- a/.github/workflows/devcontainer-ci.yml
+++ b/.github/workflows/devcontainer-ci.yml
@@ -36,7 +36,7 @@ jobs:
       # have confirmed all required hosts in the audit logs.
       # SHA pinned; Renovate keeps this up to date (see .github/renovate.json).
       - name: Harden Runner
-        uses: step-security/harden-runner@ec9f347b7fe90c3e21c3dcc695e6a78f01c4d23d  # v2.10.4
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
         with:
           egress-policy: audit
 


### PR DESCRIPTION
## Summary

- The SHA pinned for `step-security/harden-runner` in the previous commit was fabricated and did not correspond to any real commit, causing the CI job to fail at action resolution.
- Looked up the real SHA for the latest release (`v2.19.1`) via the GitHub API and replaced it.

## Root cause

`step-security/harden-runner@ec9f347b...` — this SHA does not exist in the upstream repo. The correct commit SHA for `v2.19.1` is `a5ad31d6a139d249332a2605b85202e8c0b78450`.

## Test plan

- [ ] CI job `Build devcontainer image` passes after merge